### PR TITLE
[FEAT-11] Implements Actuator

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -36,6 +36,7 @@
         <postgresql.version>42.7.2</postgresql.version>
         <springdoc-openapi.version>2.3.0</springdoc-openapi.version>
         <jsonwebtoken.version>0.12.3</jsonwebtoken.version>
+        <spring-boot-starter-actuator.version>3.4.0</spring-boot-starter-actuator.version>
     </properties>
 
     <dependencies>
@@ -115,6 +116,12 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-aop</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+            <version>${spring-boot-starter-actuator.version}</version>
         </dependency>
     </dependencies>
 

--- a/backend/src/main/java/orb/com/backend/config/security/SecurityConfig.java
+++ b/backend/src/main/java/orb/com/backend/config/security/SecurityConfig.java
@@ -36,6 +36,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/v1/orb/auth/**").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/orb/customer").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/health").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -35,3 +35,32 @@ springdoc:
     tagsSorter: alpha
 jwt:
   secret: ${JWT_SECRET}
+
+
+management:
+  endpoints:
+    enabled-by-default: false
+    web:
+      base-path: /
+      exposure:
+        include: health
+  endpoint:
+    health:
+      enabled: true
+      group:
+        liveness:
+          include: livenessState, ping
+        readiness:
+          include: readinessState, ping
+      show-details: "NEVER"
+      probes:
+        enabled: true
+  health:
+    ping:
+      enabled: true
+    diskspace:
+      enabled: false
+    livenessState:
+      enabled: true
+    readinessState:
+      enabled: true


### PR DESCRIPTION
This pull request introduces the Spring Boot Actuator to the project, enabling health check endpoints and updating security configurations to allow public access to the `/health` endpoint. Key changes include dependency updates, configuration additions, and security adjustments.

### Dependency Updates:
* Added `spring-boot-starter-actuator` dependency to `pom.xml` with version `3.4.0`. [[1]](diffhunk://#diff-34049c3bc6deee4bbf269544338e0450399140da63fec684096d1ae0ce70b4bbR39) [[2]](diffhunk://#diff-34049c3bc6deee4bbf269544338e0450399140da63fec684096d1ae0ce70b4bbR120-R125)

### Configuration Changes:
* Updated `application.yml` to configure Actuator management endpoints, enabling the `/health` endpoint with specific health probes (`livenessState`, `readinessState`, and `ping`).

### Security Adjustments:
* Modified `SecurityConfig.java` to allow public access to the `/health` endpoint in the security filter chain.